### PR TITLE
Feature/tesseract conf flag

### DIFF
--- a/app/ocr.py
+++ b/app/ocr.py
@@ -1,6 +1,7 @@
 import re
 import pytesseract
 from pdf2image import convert_from_bytes
+import pandas as pd
 
 
 def ocr(bts: bytes, dpi=90) -> str:
@@ -9,22 +10,74 @@ def ocr(bts: bytes, dpi=90) -> str:
     clean_text = re.sub(r"\s+", " ", text)
     return clean_text
 
+def ocr_conf_flag(bts: bytes, dpi=90, conf_threshold=30):
+    """
+    Convert pdf to document words and flag for low confidence documents.
+    Argument: 1) Byte string, output from BoxWrapper.download_file(file_id)
+              2) dpi: integer, sets resolution of image converted from pdfs
+              3) conf_threshold: integer, determines level of document confidence under which to set conf_flag
+
+    Returns: Document words, a flag if document confidence is less than conf_threshold
+    """
+    # pdf handler
+    pages = convert_from_bytes(bts, dpi=dpi)
+
+    str_list = []
+    for i in range(len(pages)):
+        # for multi-page pdfs: concatenate each pages data to one list
+        page_data = pytesseract.image_to_data(pages[i])
+        if i == 0:
+            # keep the column names on the first page
+            str_list = str_list + page_data.split('\n')[:-1]
+        else:
+            # drop column names on subsequent pages
+            str_list = str_list + page_data.split('\n')[1:-1]
+
+    # split-out elements
+    data_df = pd.DataFrame([x.split('\t') for x in str_list])
+    # set first line as column names
+    data_df.columns = data_df.iloc[0]
+    # drop first row: names,
+    data_df = data_df.iloc[1:]
+    data_df = data_df[['text', 'conf']]
+    # convert confidence values to int for mean(), filtering
+    data_df['conf'] = data_df['conf'].astype('int')
+    # get mean
+    conf_mean = data_df['conf'].mean()
+    # print('CONF_MEAN: ', conf_mean) # for test
+    # set confidence flag
+    conf_flag =  conf_mean < conf_threshold
+    # make string from column of words
+    out_str = " ".join(data_df['text'].tolist())
+
+    return out_str, conf_flag
+
+
+
 
 if __name__ == '__main__':
     from app.box_wrapper import BoxWrapper
 
     box = BoxWrapper()
-    file_id = "23470520869"
-    info = box.get_file_info(file_id)
-    info['text'] = ocr(box.download_file(file_id), 200)
-    for key, val in info.items():
-        if key == "text":
-            print(f"{key} : {val[:200]}")
-        else:
-            if isinstance(val, dict):
-                print(key + ": {")
-                for k, v in val.items():
-                    print(f"    {k} : {v}")
-                print("}")
-            else:
-                print(f"{key} : {val}")
+    # file_id = "23470520869" #legible, straight, typwritten doc. Mean confidence: 70%
+    # file_id = "305364848415" #news paper clippings, bad photos. Mean confidence: 59%
+    # file_id = "17742201678" #crude map with some text and labels. Mean_confidence: 29%
+    file_id = "8281189693" #side_ways tabular docs: 19%
+
+    pdf_bytes = box.download_file(file_id)
+
+    print(ocr_conf_flag(pdf_bytes, 300, 40))
+
+    # info = box.get_file_info(file_id)
+    # info['text'] = ocr(box.download_file(file_id), 200)
+    # for key, val in info.items():
+    #     if key == "text":
+    #         print(f"{key} : {val[:200]}")
+    #     else:
+    #         if isinstance(val, dict):
+    #             print(key + ": {")
+    #             for k, v in val.items():
+    #                 print(f"    {k} : {v}")
+    #             print("}")
+    #         else:
+    #             print(f"{key} : {val}")

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -2,7 +2,6 @@ import re
 import pytesseract
 from pdf2image import convert_from_bytes
 import pandas as pd
-import time
 
 
 def ocr(bts: bytes, dpi=90) -> str:
@@ -46,7 +45,6 @@ def ocr_conf_mean(bts: bytes, dpi=150):
     data_df['conf'] = data_df['conf'].astype('int')
     # get mean
     conf_mean = data_df['conf'].mean()
-    # print('CONF_MEAN: ', conf_mean) # for test
 
     # make string from column of words
     out_str = " ".join(data_df['text'].tolist())
@@ -66,29 +64,11 @@ if __name__ == '__main__':
     # file_id = "305364848415".
     #crude map with some text and labels. Mean_confidence: 29%. 1% time overhead with Mean_confidence
     # file_id = "17742201678"
-    #side_ways tabular docs. Mean_confidence: 19%. 1% time overhead with Mean_confidence
-    file_id = "8281189693"
+    #side-ways tabular docs. Mean_confidence: 19%. 1% time overhead with Mean_confidence
+    # file_id = "8281189693"
 
     pdf_bytes = box.download_file(file_id)
+    print(ocr_conf_mean(pdf_bytes, 300))
+    # print(ocr(pdf_bytes, 300))
 
-    s = time.time()
-    ocr_conf_mean(pdf_bytes, 300)
-    print('with confidence:', time.time() - s)
 
-    s = time.time()
-    ocr(pdf_bytes, 300)
-    print('without confidence:', time.time() - s)
-
-    # info = box.get_file_info(file_id)
-    # info['text'] = ocr(box.download_file(file_id), 200)
-    # for key, val in info.items():
-    #     if key == "text":
-    #         print(f"{key} : {val[:200]}")
-    #     else:
-    #         if isinstance(val, dict):
-    #             print(key + ": {")
-    #             for k, v in val.items():
-    #                 print(f"    {k} : {v}")
-    #             print("}")
-    #         else:
-    #             print(f"{key} : {val}")

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -13,8 +13,8 @@ def ocr(bts: bytes, dpi=90) -> str:
 def ocr_conf_mean(bts: bytes, dpi=150):
     """
     Convert pdf to document words and mean tesseract confidence.
-    Argument: 1) bts (bytestring): Byte string, output from BoxWrapper.download_file(file_id)
-              2) dpi (int): integer, sets resolution of image converted from pdfs
+    Argument: 1) bts (bytestring): pdf byte string, output from BoxWrapper.download_file(file_id)
+              2) dpi (int): sets resolution of image converted from pdfs
 
     Returns: A tuple containing:
         1) str: String of unformated document words

--- a/app/ocr.py
+++ b/app/ocr.py
@@ -13,11 +13,11 @@ def ocr(bts: bytes, dpi=90) -> str:
 def ocr_conf_flag(bts: bytes, dpi=90, conf_threshold=30):
     """
     Convert pdf to document words and flag for low confidence documents.
-    Argument: 1) Byte string, output from BoxWrapper.download_file(file_id)
+    Argument: 1) bts: Byte string, output from BoxWrapper.download_file(file_id)
               2) dpi: integer, sets resolution of image converted from pdfs
               3) conf_threshold: integer, determines level of document confidence under which to set conf_flag
 
-    Returns: Document words, a flag if document confidence is less than conf_threshold
+    Returns: (Document words, a flag if document confidence is less than conf_threshold)
     """
     # pdf handler
     pages = convert_from_bytes(bts, dpi=dpi)


### PR DESCRIPTION
## Description

Adds an alternative tesseracting function to the ocr.py file, which returns Tesseract document words and the mean Tesseract confidence of all words in the document. The addition of a confidence metric per document could be used to supply our users with a sense of the fidelity between searchable documents and document images in the National Archives Box repo. It could also be used to suggest documents that need to be re-scanned or corrected (ie rotated 90 deg). There is some time overhead using this function instead of ocr() which ranged from 1% to 8% in testing.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] I have made corresponding changes to the documentation if necessary (optional)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes

[loom video](https://www.loom.com/share/470c282a8fcf47b19ba7dd483fd007b5)
[trello card](https://trello.com/c/KegWEqaQ)